### PR TITLE
Fix error when credential file directory does not exist

### DIFF
--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -24,6 +24,7 @@ module Oneaws
       if options["update_aws_credentials"]
         credential_file = File.expand_path("~/.aws/credentials")
         unless inifile = IniFile.load(credential_file)
+          FileUtils.mkdir_p(File.dirname(credential_file))
           inifile = IniFile.new
         end
 


### PR DESCRIPTION
Fix error when credential file directory like `~/.aws/` does not exist.

```
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/t-yano/.aws/credentials
```