### PR TITLE
XDG 準拠のフォルダレイアウトに対応した

### DIFF
--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -59,7 +59,7 @@ module Oneaws
     # 2. ~/.config/aws/credentials
     # 存在しない場合は順番1つ目のものを用いる
     def find_credentials
-      credentials = ["~/.aws/credentials", "~/config/aws/credentials"]
+      credentials = ["~/.aws/credentials", "~/.config/aws/credentials"]
       credential = credentials.find{|c| File.exists? File.expand_path(c) }
       if credential
         credential

--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -22,7 +22,7 @@ module Oneaws
       credential = client.issue_credential(params)
 
       if options["update_aws_credentials"]
-        credential_file = File.expand_path("~/.aws/credentials")
+        credential_file = File.expand_path(find_credentials)
         unless inifile = IniFile.load(credential_file)
           FileUtils.mkdir_p(File.dirname(credential_file))
           inifile = IniFile.new
@@ -50,6 +50,12 @@ module Oneaws
         set -x AWS_SESSION_TOKEN '#{credential.session_token}'
         EOS
       end
+    end
+
+    private
+
+    def find_credentials
+      "~/.aws/credentials"
     end
   end
 end

--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -54,8 +54,18 @@ module Oneaws
 
     private
 
+    # AWS の credential を以下の順番で存在チェックをする
+    # 1. ~/.aws/credentials
+    # 2. ~/.aws/config/credentials
+    # 存在しない場合は順番1つ目のものを用いる
     def find_credentials
-      "~/.aws/credentials"
+      credentials = ["~/.aws/credentials", "~/config/aws/credentials"]
+      credential = credentials.find{|c| File.exists? File.expand_path(c) }
+      if credential
+        credential
+      else
+        credentials.first
+      end
     end
   end
 end

--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -56,7 +56,7 @@ module Oneaws
 
     # AWS の credential を以下の順番で存在チェックをする
     # 1. ~/.aws/credentials
-    # 2. ~/.aws/config/credentials
+    # 2. ~/.config/aws/credentials
     # 存在しない場合は順番1つ目のものを用いる
     def find_credentials
       credentials = ["~/.aws/credentials", "~/config/aws/credentials"]


### PR DESCRIPTION
`~/.config/aws/credentials` があるときに使うように対応しました。存在しない場合は従来通り `~/.aws/credentials` を使います。