### PR TITLE
Accept OTP input if device type is not OneLogin Protect

### DIFF
--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -1,5 +1,6 @@
 require 'onelogin'
 require 'aws-sdk-core'
+require 'io/console'
 
 module Oneaws
   class Client
@@ -32,13 +33,20 @@ module Oneaws
       mfa = response.mfa
 
       # sent push notification to OneLogin Protect
-      mfa_device = mfa.devices.select{|device| device.type == "OneLogin Protect"}&.first
+      mfa_device = mfa.devices[0]
 
       if mfa_device.nil?
-        raise MfaDeviceNotFoundError.new("OneLogin Protect device not found.")
+        raise MfaDeviceNotFoundError.new("MFA device not found.")
       end
 
-      response = @onelogin.get_saml_assertion_verifying(app_id, mfa_device.id, mfa.state_token, nil, nil, false)
+      otp_token = nil
+      if mfa_device.type != "OneLogin Protect"
+        print "input OTP of #{mfa_device.type}: "
+        otp_token = STDIN.noecho(&:gets)
+      end
+
+      response = @onelogin.get_saml_assertion_verifying(app_id, mfa_device.id, mfa.state_token, otp_token, nil, false)
+      
       if response.nil?
         raise SamlRequestError.new("#{@onelogin.error} #{@onelogin.error_description}")
       end

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -43,7 +43,6 @@ module Oneaws
         "OneLogin Protect"
       ]
 
-      otp_token = nil
       otp_token = unless device_types_that_do_not_require_token.include?(mfa_device.type)
         print "input OTP of #{mfa_device.type}: "
         STDIN.noecho(&:gets)

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -33,18 +33,18 @@ module Oneaws
       mfa = response.mfa
 
       # sent push notification to OneLogin Protect
-      supported_device_types = [
-        "OneLogin Protect",
-        "Google Authenticator"
-      ]
-      mfa_device = mfa.devices.select{|device| supported_device_types.include?(device.type)}&.first
+      mfa_device = mfa.devices.first
 
       if mfa_device.nil?
         raise MfaDeviceNotFoundError.new("MFA device not found.")
       end
 
+      device_types_that_do_not_require_token = [
+        "OneLogin Protect"
+      ]
+
       otp_token = nil
-      otp_token = if mfa_device.type != "OneLogin Protect"
+      otp_token = unless device_types_that_do_not_require_token.include?(mfa_device.type)
         print "input OTP of #{mfa_device.type}: "
         STDIN.noecho(&:gets)
       end

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -33,7 +33,7 @@ module Oneaws
       mfa = response.mfa
 
       # sent push notification to OneLogin Protect
-      mfa_device = mfa.devices[0]
+      mfa_device = mfa.devices.first
 
       if mfa_device.nil?
         raise MfaDeviceNotFoundError.new("MFA device not found.")

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -33,7 +33,11 @@ module Oneaws
       mfa = response.mfa
 
       # sent push notification to OneLogin Protect
-      mfa_device = mfa.devices.first
+      supported_device_types = [
+        "OneLogin Protect",
+        "Google Authenticator"
+      ]
+      mfa_device = mfa.devices.select{|device| supported_device_types.include?(device.type)}&.first
 
       if mfa_device.nil?
         raise MfaDeviceNotFoundError.new("MFA device not found.")

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -44,9 +44,9 @@ module Oneaws
       end
 
       otp_token = nil
-      if mfa_device.type != "OneLogin Protect"
+      otp_token = if mfa_device.type != "OneLogin Protect"
         print "input OTP of #{mfa_device.type}: "
-        otp_token = STDIN.noecho(&:gets)
+        STDIN.noecho(&:gets)
       end
 
       response = @onelogin.get_saml_assertion_verifying(app_id, mfa_device.id, mfa.state_token, otp_token, nil, false)


### PR DESCRIPTION
MFAデバイスとしてプッシュ通知に対応していないGoogle Authenticatorなどを使用する場合でもOTPを入力して利用できるようにします。
`mfa_device.type`が`"OneLogin Protect"`である場合は従来通りOTPを`nil`とすることでプッシュ通知を飛ばさせ、そうでない場合はOTPの入力を受け付けた上でverifyingを行います。