### PR TITLE
Ruby 3.2で廃止されたFile.exists?の代わりにFile.exist?を使う

### DIFF
--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -60,7 +60,7 @@ module Oneaws
     # 存在しない場合は順番1つ目のものを用いる
     def find_credentials
       credentials = ["~/.aws/credentials", "~/.config/aws/credentials"]
-      credential = credentials.find{|c| File.exists? File.expand_path(c) }
+      credential = credentials.find{|c| File.exist? File.expand_path(c) }
       if credential
         credential
       else


### PR DESCRIPTION
Ruby 3.2で実行すると次のエラーが発生します。廃止された`File.exists?`を使っているのが原因なので[`File.exist?`](https://docs.ruby-lang.org/ja/latest/method/File/s/exist=3f.html)に置き換えます

cf. https://github.com/ruby/ruby/blob/v3_2_0/NEWS.md#removed-methods

```
$ oneaws -p <profile>
(snip)
/Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oneaws-0.2.0/lib/oneaws/cli.rb:63:in `block in find_credentials': undefined method `exists?' for File:Class (NoMethodError)

      credential = credentials.find{|c| File.exists? File.expand_path(c) }
                                            ^^^^^^^^
Did you mean?  exist?
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oneaws-0.2.0/lib/oneaws/cli.rb:63:in `each'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oneaws-0.2.0/lib/oneaws/cli.rb:63:in `find'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oneaws-0.2.0/lib/oneaws/cli.rb:63:in `find_credentials'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oneaws-0.2.0/lib/oneaws/cli.rb:25:in `getkey'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /Users/kymmt90/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oneaws-0.2.0/exe/oneaws:6:in `<top (required)>'
	from /Users/kymmt90/.rbenv/versions/3.2.0/bin/oneaws:25:in `load'
	from /Users/kymmt90/.rbenv/versions/3.2.0/bin/oneaws:25:in `<main>'
```