### PR TITLE
duration_secondsを環境変数で設定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ export ONELOGIN_APP_ID=<your onelogin app_id>
 export ONELOGIN_SUBDOMAIN=<your onelogin subdomain>
 export AWS_ROLE_ARN=<your aws role arn>
 export AWS_PRINCIPAL_ARN=<your aws idp arn>
+export DURATION_SECONDS=<token duration(sec)> # Option: default 3600
 
 # fish
 set -x ONELOGIN_CLIENT_ID <your onelogin client id>
@@ -26,6 +27,7 @@ set -x ONELOGIN_APP_ID <your onelogin app_id>
 set -x ONELOGIN_SUBDOMAIN <your onelogin subdomain>
 set -x AWS_ROLE_ARN <your aws role arn>
 set -x AWS_PRINCIPAL_ARN <your aws idp arn>
+set -x DURATION_SECONDS <token duration(sec)> # Option: default 3600
 ```
 
 環境変数を設定したら実行します。

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -65,7 +65,7 @@ module Oneaws
       saml_assertion = response.saml_response
 
       params = {
-        duration_seconds: 28800,
+        duration_seconds: (ENV['DURATION_SECONDS'] || 3600).to_i,
         principal_arn: ENV['AWS_PRINCIPAL_ARN'],
         role_arn: ENV['AWS_ROLE_ARN'],
         saml_assertion: saml_assertion,

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -65,7 +65,7 @@ module Oneaws
       saml_assertion = response.saml_response
 
       params = {
-        duration_seconds: 3600,
+        duration_seconds: 28800,
         principal_arn: ENV['AWS_PRINCIPAL_ARN'],
         role_arn: ENV['AWS_ROLE_ARN'],
         saml_assertion: saml_assertion,


### PR DESCRIPTION
セッショントークンの有効期間を環境変数で設定できるようにします。
有効期間の最大値はroleのmaximum session durationの値に依存するので、利用する側のポリシーで調整できるようにします。