### PR TITLE
複数のデバイスが利用可能な場合、ターミナルで選択できるようにする

### DIFF
--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -31,13 +31,20 @@ module Oneaws
       end
 
       mfa = response.mfa
-
-      # sent push notification to OneLogin Protect
-      mfa_device = mfa.devices.first
-
-      if mfa_device.nil?
-        raise MfaDeviceNotFoundError.new("MFA device not found.")
+      puts "\nAvailable MFA devices:"
+      
+      mfa.devices.each_with_index do |device, index|
+        puts "#{index + 1}. #{device.type} (ID: #{device.id})"
       end
+
+      print "\nSelect MFA device (1-#{mfa.devices.length}): "
+      selection = STDIN.gets.chomp.to_i
+
+      if selection < 1 || selection > mfa.devices.length
+        raise MfaDeviceNotFoundError.new("Invalid device selection.")
+      end
+
+      mfa_device = mfa.devices[selection - 1]
 
       device_types_that_do_not_require_token = [
         "OneLogin Protect"

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -31,20 +31,24 @@ module Oneaws
       end
 
       mfa = response.mfa
-      puts "\nAvailable MFA devices:"
       
-      mfa.devices.each_with_index do |device, index|
-        puts "#{index + 1}. #{device.type} (ID: #{device.id})"
+      if mfa.devices.length == 1
+        mfa_device = mfa.devices.first
+      else
+        puts "\nAvailable MFA devices:"
+        mfa.devices.each_with_index do |device, index|
+          puts "#{index + 1}. #{device.type} (ID: #{device.id})"
+        end
+
+        print "\nSelect MFA device (1-#{mfa.devices.length}): "
+        selection = STDIN.gets.chomp.to_i
+
+        if selection < 1 || selection > mfa.devices.length
+          raise MfaDeviceNotFoundError.new("Invalid device selection.")
+        end
+
+        mfa_device = mfa.devices[selection - 1]
       end
-
-      print "\nSelect MFA device (1-#{mfa.devices.length}): "
-      selection = STDIN.gets.chomp.to_i
-
-      if selection < 1 || selection > mfa.devices.length
-        raise MfaDeviceNotFoundError.new("Invalid device selection.")
-      end
-
-      mfa_device = mfa.devices[selection - 1]
 
       device_types_that_do_not_require_token = [
         "OneLogin Protect"


### PR DESCRIPTION
複数の2FAデバイスがある場合、ターミナルで選べるようにしました

こんな感じで使えます

```
% oneaws 

Available MFA devices:
1. Google Authenticator (ID: xxx)
2. Google Authenticator (ID: xxx)

Select MFA device (1-2): 2
input OTP of Google Authenticator:
```

利用可能な2FAデバイスが一つの場合はこれまで通り最初のデバイスが使われます