### PR TITLE
Fix the version of aws-sdk-core

### DIFF
--- a/oneaws.gemspec
+++ b/oneaws.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk-core'
+  spec.add_dependency 'aws-sdk-core', '~> 3.206.0'
   spec.add_dependency 'inifile'
   spec.add_dependency 'onelogin', '~> 1.6'
   spec.add_dependency 'thor'


### PR DESCRIPTION
oneaws で OTP の入力後、 `undefined method `credentials' for class Aws::AssumeRoleCredentials (NoMethodError)` というエラーがでて credentials の取得に失敗します。この現象を aws-sdk-core のバージョンを下げることにより回避します。

<details>
<summary>
実行時のログ
</summary>

```
$ envchain oneaws oneaws -p foo
input OTP of Google Authenticator: /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-sts/plugins/endpoints.rb:54:in `with_metrics': undefined method `credentials' for class Aws::AssumeRoleCredentials (NoMethodError)

          if context.config.credentials&.credentials&.account_id
                                       ^^^^^^^^^^^^^
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-sts/plugins/endpoints.rb:43:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/endpoint_discovery.rb:84:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/seahorse/client/plugins/endpoint.rb:46:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/param_validator.rb:26:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/seahorse/client/plugins/raise_response_errors.rb:16:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/checksum_algorithm.rb:111:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:16:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/invocation_id.rb:16:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/idempotency_token.rb:19:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/param_converter.rb:26:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/seahorse/client/plugins/request_callback.rb:89:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/seahorse/client/plugins/response_target.rb:24:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/telemetry.rb:39:in `block in call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/telemetry/no_op.rb:29:in `in_span'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/telemetry.rb:53:in `span_wrapper'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/telemetry.rb:39:in `call'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/seahorse/client/request.rb:72:in `send_request'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/aws-sdk-core-3.209.1/lib/aws-sdk-sts/client.rb:1289:in `assume_role_with_saml'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/oneaws-0.3.0/lib/oneaws/client.rb:73:in `issue_credential'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/oneaws-0.3.0/lib/oneaws/cli.rb:22:in `getkey'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/base.rb:584:in `start'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/oneaws-0.3.0/exe/oneaws:6:in `<top (required)>'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/bin/oneaws:25:in `load'
        from /Users/akatsuura/.local/share/mise/installs/ruby/3.3.5/bin/oneaws:25:in `<main>'
```

</details>

### 再現方法

oneaws をインストールした時の aws-sdk-core のバージョンが 3.207.0 以上だと再現しそうです。

以下のDiffで再現します。

```diff
$ git diff
diff --git a/oneaws.gemspec b/oneaws.gemspec
index 38ffe1a..3e17a79 100644
--- a/oneaws.gemspec
+++ b/oneaws.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

-  spec.add_dependency 'aws-sdk-core'
+  spec.add_dependency 'aws-sdk-core', '~> 3.207.0'
   spec.add_dependency 'inifile'
   spec.add_dependency 'onelogin', '~> 1.6'
   spec.add_dependency 'thor'
```

3.206.0 までバージョンを下げると再現しなくなります。

```diff
$ git diff
diff --git a/oneaws.gemspec b/oneaws.gemspec
index 38ffe1a..3d9ebed 100644
--- a/oneaws.gemspec
+++ b/oneaws.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

-  spec.add_dependency 'aws-sdk-core'
+  spec.add_dependency 'aws-sdk-core', '~> 3.206.0'
   spec.add_dependency 'inifile'
   spec.add_dependency 'onelogin', '~> 1.6'
   spec.add_dependency 'thor'
```