### PR TITLE
Aws::STS::Client#new の credentials を nil にすることで #9 の例外を回避します

### DIFF
--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -15,7 +15,7 @@ module Oneaws
       })
 
       @aws = Aws::STS::Client.new(
-        credentials: Aws::AssumeRoleCredentials,
+        credentials: nil,
         region: ENV['AWS_REGION'] || 'ap-northeast-1',
       )
     end

--- a/oneaws.gemspec
+++ b/oneaws.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk-core', '~> 3.206.0'
+  spec.add_dependency 'aws-sdk-core'
   spec.add_dependency 'inifile'
   spec.add_dependency 'onelogin', '~> 1.6'
   spec.add_dependency 'thor'


### PR DESCRIPTION
## PR の内容

[Fix the version of aws-sdk-core by ikaruga777 · Pull Request #9 · pepabo/oneaws](https://github.com/pepabo/oneaws/pull/9) の例外が出ないように修正する PR です ( 加えて、aws-sdk-core  のバージョン固定を外します ) 

> oneaws で OTP の入力後、 undefined method credentials' for class Aws::AssumeRoleCredentials (NoMethodError)` というエラーがでて credentials の取得に失敗します。

## credentials: 自体の指定を無くせないのか?

以下のように `credentials` も指定しないようにすると ...

```ruby
      @aws = Aws::STS::Client.new(
        region: ENV['AWS_REGION'] || 'ap-northeast-1',
      )
```

実行時に下記の エラーメッセージが STDERR に出てしまいます [^1]

[^1]: そしてタイムアウトを待つみたいで、 oneaws の実行がもたつく

```
Error retrieving instance profile credentials: Net::ReadTimeout
```

色々試した結果、 `credentials`  を指定しない場合は 暗黙的に内部で [Class: Aws::InstanceProfileCredentials](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/InstanceProfileCredentials.html) が呼び出されているようでした。 [^2]

### 追記

[Class: Aws::STS::Client — AWS SDK for Ruby V3](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/STS/Client.html) に記載がありました

```
When :credentials are not configured directly, the following locations will be searched for credentials:

Aws.config[:credentials]
The :access_key_id, :secret_access_key, :session_token, and :account_id options.
ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'], ENV['AWS_SESSION_TOKEN'], and ENV['AWS_ACCOUNT_ID']
~/.aws/credentials
~/.aws/config
EC2/ECS IMDS instance profile - When used by default, the timeouts are very aggressive. Construct and pass an instance of Aws::InstanceProfileCredentials or Aws::ECSCredentials to enable retries and extended timeouts. Instance profile credential fetching can be disabled by setting ENV['AWS_EC2_METADATA_DISABLED'] to true.
```


[^2]: `ENV['AWS_EC2_METADATA_DISABLED'] = "true"` を設定すると出なくなる。これで切り分けしました。


### 参考

 * [Class: Aws::InstanceProfileCredentials — AWS SDK for Ruby V3](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/InstanceProfileCredentials.html)
 * [Configuring environment variables for the AWS CLI - AWS Command Line Interface](https://docs.aws.amazon.com/ja_jp/cli/v1/userguide/cli-configure-envvars.html)