### PR TITLE
環境変数 ONEAWS_MFA_DEVICE の導入 - デバイスの選択を環境変数で指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ MFA デバイスを複数登録している場合、以下のようにデバイ�
 ```
 Available MFA devices:
 1. OneLogin Protect (ID: ***)
-2. OneLogin Authn (ID: ***)
+2. OneLogin Auth (ID: ***)
 
 Select MFA device (1-2):
 ```

--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ oneaws
 ```
 
 `-u` オプションをつけていると `~/.aws/credentials` に追記されます(default: true)。
+
+### ONEAWS_MFA_DEVICE
+
+MFA デバイスを複数登録している場合、以下のようにデバイスの選択を求められます。
+
+```
+Available MFA devices:
+1. OneLogin Protect (ID: ***)
+2. OneLogin Authn (ID: ***)
+
+Select MFA device (1-2):
+```
+
+デバイスの選択が面倒な場合は、環境変数 `ONEAWS_MFA_DEVICE` を指定することで、指定した番号のデバイスを自動で選択できます。上記を例にすると、`1. OneLogin Protect` を選ぶ場合は `ONEAWS_MFA_DEVICE=1` と指定します。

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -74,6 +74,16 @@ module Oneaws
         return mfa.devices.first
       end
 
+      if selection = ENV["ONEAWS_MFA_DEVICE"] &.to_i
+
+        if selection <= 0
+          warn "ONEAWS_MFA_DEVICE must be >= 1"
+          exit 1
+        end
+
+        return mfa.devices[selection - 1]
+      end
+
       puts "\nAvailable MFA devices:"
       mfa.devices.each_with_index do |device, index|
         puts "#{index + 1}. #{device.type} (ID: #{device.id})"

--- a/lib/oneaws/client.rb
+++ b/lib/oneaws/client.rb
@@ -75,7 +75,6 @@ module Oneaws
       end
 
       if selection = ENV["ONEAWS_MFA_DEVICE"] &.to_i
-
         if selection <= 0
           warn "ONEAWS_MFA_DEVICE must be >= 1"
           exit 1


### PR DESCRIPTION
MFA デバイスを複数登録している場合、以下のようにデバイスの選択を求められます。

```
Available MFA devices:
1. OneLogin Protect (ID: ***)
2. OneLogin Authn (ID: ***)
Select MFA device (1-2):
```

とてもユーザフレンドリーな UI ですが ... 毎回同じデバイスを使う場合は選択をスキップしたくなります 🫤 

## ONEAWS_MFA_DEVICE 環境変数の導入

`ONEAWS_MFA_DEVICE` という環境変数を導入し、デバイスの選択を環境変数でできるようにします。

`1. OneLogin Protect` を選ぶ場合は `ONEAWS_MFA_DEVICE=1` と指定する感じです

```sh
$ ONEAWS_MFA_DEVICE=1 bundle exec exe/oneaws  
```

## レビューのポイント

 * `ONEAWS_MFA_DEVICE` 以外でいい名前あるかな?
 * コード見て変なとこないか?