### PR TITLE
base64, logger を追加して、warning を抑制 / LoadedError を直します

### DIFF
--- a/oneaws.gemspec
+++ b/oneaws.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'inifile'
   spec.add_dependency 'onelogin', '~> 1.6'
   spec.add_dependency 'thor'
+  spec.add_dependency 'base64'
+  spec.add_dependency 'logger'
 end


### PR DESCRIPTION
Ruby 3.4.1 で実行すると以下の warning , 例外が出るので spec.add_dependency を追加します

```
    $ bundle exec exe/oneaws
    /Users/***/src/github.com/pepabo/oneaws/vendor/bundle/ruby/3.4.0/gems/aws-sdk-core-3.206.0/lib/seahorse/client/net_http/connection_pool.rb:8: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add logger to your Gemfile or gemspec to silence this warning.
    /Users/***/src/github.com/pepabo/oneaws/vendor/bundle/ruby/3.4.0/gems/aws-sdk-core-3.206.0/lib/aws-sdk-core/assume_role_web_identity_credentials.rb:5: warning: base64 was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
    You can add base64 to your Gemfile or gemspec to silence this warning.
    bundler: failed to load command: exe/oneaws (exe/oneaws)
    /Users/***/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- base64 (LoadError)
    	from /Users/***/.rbenv/versions/3.4.1/lib/ruby/3.4.
```