### PR TITLE
Trusted Publishing の仕組みをつかって Gem をリリースするためのワークフローを追加する

### DIFF
--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -1,0 +1,40 @@
+name: Publish gem to rubygems.org
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'pepabo/oneaws'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: rubygems.org
+      url: https://rubygems.org/gems/oneaws
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1

--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -22,19 +22,20 @@ jobs:
       id-token: write
 
     steps:
+      # Set up
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@fb404b9557c186e349162b0d8efb06e2bc36edea # v1.232.0
         with:
           bundler-cache: true
           ruby-version: ruby
 
       # Release
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@9e85cb11501bebc2ae661c1500176316d3987059 # v1


### PR DESCRIPTION
タグ切ったら gem push されたい。gem push には Trusted Publishing の仕組みを使う。

ref: https://guides.rubygems.org/trusted-publishing/adding-a-publisher/

https://github.com/segiddins/rubygems-await/blob/main/.github/workflows/push_gem.yml を大いに参考にした。