### PR TITLE
Add ONEAWS_OTP_CODE environment variable support for --otp option

### DIFF
--- a/lib/oneaws/cli.rb
+++ b/lib/oneaws/cli.rb
@@ -10,7 +10,7 @@ module Oneaws
     option :update_aws_credentials, aliases: "-u", type: :boolean, default: true
     option :profile, aliases: "-p", type: :string, default: "oneaws"
     option :eval, type: :string, enum: ["bash", "fish"]
-    option :otp, type: :string
+    option :otp, type: :string, default: ENV['ONEAWS_OTP_CODE']
     def getkey
       client = Client.new
 


### PR DESCRIPTION
`$ONEAWS_OTP_CODE` でもOTPを設定できるようにします