### PR TITLE
openssl の依存を明示する

### DIFF
--- a/oneaws.gemspec
+++ b/oneaws.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'base64'
   spec.add_dependency 'logger'
+  spec.add_dependency 'openssl'
 end


### PR DESCRIPTION
OpenSSL 3.6.0 を利用している時、 gem の openssl のバージョンが 3.3.0 以上であることが実質求められるので、依存として含めてしまいます。